### PR TITLE
Add props to set custom wrapper & child tags

### DIFF
--- a/example/FadeInTest.js
+++ b/example/FadeInTest.js
@@ -49,8 +49,17 @@ export default class FadeInTest extends Component {
           <Element>Element 5</Element>
           <Element>Element 6</Element>
         </FadeIn>
-        <Title>With Custom Wrapper Tag (section)</Title>
+        <Title>With Custom Wrapper Tag (&lt;section&gt;)</Title>
         <FadeIn wrapperTag="section">
+          <Element>Element 1</Element>
+          <Element>Element 2</Element>
+          <Element>Element 3</Element>
+          <Element>Element 4</Element>
+          <Element>Element 5</Element>
+          <Element>Element 6</Element>
+        </FadeIn>
+        <Title>With Custom Child Tag (&lt;section&gt;)</Title>
+        <FadeIn childTag="section">
           <Element>Element 1</Element>
           <Element>Element 2</Element>
           <Element>Element 3</Element>

--- a/example/FadeInTest.js
+++ b/example/FadeInTest.js
@@ -49,6 +49,15 @@ export default class FadeInTest extends Component {
           <Element>Element 5</Element>
           <Element>Element 6</Element>
         </FadeIn>
+        <Title>With Custom Wrapper Tag (section)</Title>
+        <FadeIn wrapperTag="section">
+          <Element>Element 1</Element>
+          <Element>Element 2</Element>
+          <Element>Element 3</Element>
+          <Element>Element 4</Element>
+          <Element>Element 5</Element>
+          <Element>Element 6</Element>
+        </FadeIn>
         <style>{`
           .container {
             border: 1px solid blue;

--- a/src/FadeIn.js
+++ b/src/FadeIn.js
@@ -34,12 +34,13 @@ export default class FadeIn extends Component {
   render() {
     const transitionDuration = this.transitionDuration;
     const WrapperTag = this.props.wrapperTag || "div";
+    const ChildTag = this.props.childTag || "div";
 
     return (
       <WrapperTag className={this.props.className}>
         {React.Children.map(this.props.children, (child, i) => {
           return (
-            <div
+            <ChildTag
               className={this.props.childClassName}
               style={{
                 transition: `opacity ${transitionDuration}ms, transform ${transitionDuration}ms`,
@@ -48,7 +49,7 @@ export default class FadeIn extends Component {
               }}
             >
               {child}
-            </div>
+            </ChildTag>
           );
         })}
       </WrapperTag>

--- a/src/FadeIn.js
+++ b/src/FadeIn.js
@@ -33,8 +33,10 @@ export default class FadeIn extends Component {
 
   render() {
     const transitionDuration = this.transitionDuration;
+    const WrapperTag = this.props.wrapperTag || "div";
+
     return (
-      <div className={this.props.className}>
+      <WrapperTag className={this.props.className}>
         {React.Children.map(this.props.children, (child, i) => {
           return (
             <div
@@ -49,7 +51,7 @@ export default class FadeIn extends Component {
             </div>
           );
         })}
-      </div>
+      </WrapperTag>
     );
   }
 }


### PR DESCRIPTION
This PR adds the ability to set a custom HTML element for the wrapper.

Addresses https://github.com/gkaemmer/react-fade-in/issues/11.

P.S. - I'm a big fan of this library! Such a quick and easy way to add list transitions to a React app.