### PR TITLE
issue-16 remove translateY once transition is complete to avoid issue…

### DIFF
--- a/src/FadeIn.js
+++ b/src/FadeIn.js
@@ -44,7 +44,7 @@ export default class FadeIn extends Component {
               className={this.props.childClassName}
               style={{
                 transition: `opacity ${transitionDuration}ms, transform ${transitionDuration}ms`,
-                transform: this.state.maxIsVisible ? 'none' : `translateY(${this.state.maxIsVisible > i ? 0 : 20}px)`,
+                transform: this.state.maxIsVisible > i ? 'none' : 'translateY(20px)',
                 opacity: this.state.maxIsVisible > i ? 1 : 0
               }}
             >

--- a/src/FadeIn.js
+++ b/src/FadeIn.js
@@ -44,7 +44,7 @@ export default class FadeIn extends Component {
               className={this.props.childClassName}
               style={{
                 transition: `opacity ${transitionDuration}ms, transform ${transitionDuration}ms`,
-                transform: `translateY(${this.state.maxIsVisible > i ? 0 : 20}px)`,
+                transform: this.state.maxIsVisible ? 'none' : `translateY(${this.state.maxIsVisible > i ? 0 : 20}px)`,
                 opacity: this.state.maxIsVisible > i ? 1 : 0
               }}
             >


### PR DESCRIPTION
fixes:
https://github.com/gkaemmer/react-fade-in/issues/16
Once the transition is complete, we should not transform the element anymore. because it affects fixed children elements

proof that using transform: none also gives animation when changing from transform: translateY :
https://jsfiddle.net/egv6cs1x/3/