### PR TITLE
0ms Transition and Delay times

### DIFF
--- a/src/FadeIn.tsx
+++ b/src/FadeIn.tsx
@@ -18,8 +18,8 @@ interface Props {
 
 export default function FadeIn(props: PropsWithChildren<Props>) {
   const [maxIsVisible, setMaxIsVisible] = useState(0);
-  const transitionDuration = props.transitionDuration || 400;
-  const delay = props.delay || 50;
+  const transitionDuration = typeof props.transitionDuration === "number" ? props.transitionDuration : 400;
+  const delay = typeof props.delay === "number" ? props.delay : 50;
   const WrapperTag = props.wrapperTag || "div";
   const ChildTag = props.childTag || "div";
   const visible = typeof props.visible === "undefined" ? true : props.visible;


### PR DESCRIPTION
Added the ability to set transition duration and delay to 0 without defaulting them back to the 400ms and 50ms defaults (since 0 resolves to "false")