### PR TITLE
Support for React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "webpack-dev-server": "^3.10.1"
   },
   "peerDependencies": {
-    "react": "^16.8 || 17"
+    "react": "^16.8 || 17 || 18",
+    "react-dom": "^16.8 || 17 || 18"
   }
 }


### PR DESCRIPTION
This change adds support for React v18+ to the library. I believe many users (like myself) frequently use this lib and have encountered the same issues when running basically any npm commands that requires the use of the --force flag when using this library. This update should help resolve those issues and make it more convenient for everyone.